### PR TITLE
Make better use of Debian packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:wheezy
 
 RUN apt-get update \
 	&& apt-get install -y python curl \
-	&& curl -SL 'https://bootstrap.pypa.io/get-pip.py' | python
+	&& apt-get install -y python-pip
 
 # Force stdin, stdout and stderr to be totally unbuffered
 ENV PYTHONUNBUFFERED 1
@@ -13,6 +13,7 @@ WORKDIR /app
 
 ADD requirements.txt /app/
 
+RUN apt-get install -y python-flask python-yaml python-mock python-nose python-coverage
 RUN pip install -r requirements.txt
 
 ADD . /app/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use same base as postgres to minimize total size
-FROM debian:wheezy
+FROM debian:jessie
 
 RUN apt-get update \
 	&& apt-get install -y python curl \
@@ -13,7 +13,7 @@ WORKDIR /app
 
 ADD requirements.txt /app/
 
-RUN apt-get install -y python-flask python-yaml python-mock python-nose python-coverage
+RUN apt-get install -y python-flask python-yaml python-mock python-nose python-coverage python-docker python-blinker
 RUN pip install -r requirements.txt
 
 ADD . /app/

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get update \
 	&& apt-get install -y python curl \
 	&& curl -SL 'https://bootstrap.pypa.io/get-pip.py' | python
 
+# Force stdin, stdout and stderr to be totally unbuffered
 ENV PYTHONUNBUFFERED 1
 
 RUN mkdir /app

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ A service for the TSP MOOC platform right on your computer that let you acces, m
 
 ## Run container
 
+Run from already made container images (fmonniot/tsp-mooc-overview).
+
 ```sh
 # With boot2docker
 docker run -it -p 5000:5000 --name tsp-mooc-overview \
@@ -22,7 +24,9 @@ docker run -it -p 5000:5000 --name tsp-mooc-overview \
            fmonniot/tsp-mooc-overview
 ```
 
-## Tests
+## Development and Tests
+
+Requires [Fig](http://www.fig.sh/) to locally build a docker image (see fig.yml and Dockerfile).
 
 ```sh
 # Running tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Web dev. framework
 #flask
 # API client for docker
-docker-py>=0.7
+#docker-py>=0.7
 # YAML library for python
 #pyyaml
 # Python Mocking and Patching Library for Testing
@@ -12,4 +12,4 @@ docker-py>=0.7
 #coverage
 Flask-Testing
 # Fast, simple object-to-object and broadcast signaling
-blinker
+#blinker

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,15 @@
 # Web dev. framework
-flask
+#flask
 # API client for docker
 docker-py>=0.7
 # YAML library for python
-pyyaml
+#pyyaml
 # Python Mocking and Patching Library for Testing
-mock
+#mock
 # extends unittest to make testing easier
-nose
 # Code coverage measurement
-coverage
+#nose
+#coverage
 Flask-Testing
 # Fast, simple object-to-object and broadcast signaling
 blinker

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,15 @@
+# Web dev. framework
 flask
+# API client for docker
 docker-py>=0.7
+# YAML library for python
 pyyaml
+# Python Mocking and Patching Library for Testing
 mock
+# extends unittest to make testing easier
 nose
+# Code coverage measurement
 coverage
 Flask-Testing
+# Fast, simple object-to-object and broadcast signaling
 blinker


### PR DESCRIPTION
Whenever Python libs are packaged for Debian, I'd advise to use them, instead of pulling the latest from fig.

This is not really optimal for portability purposes, but since Debian is a requirements, let's push it to its full potential.

Also, switch to jessie to test it along the way
